### PR TITLE
fix: set local adapter SERVER_URL default (supersedes #55)

### DIFF
--- a/backend/env.template
+++ b/backend/env.template
@@ -78,9 +78,10 @@ ADMIN_PASSWORD=secure
 ##############################################################################################################
 # Variables below only required for local adapter call using script scripts/run-adapter-image.bash
 ##############################################################################################################
-SERVER_URL="$FULLY_QUALIFIED_HOSTNAME"
+SERVER_URL="http://host.docker.internal:8000"
 REPORT_FILE_NAME="dependency-check-report.json"
 FILE_FORMAT="json"
 TOOL_NAME="owasp"
 PROJECT_ID="some-project-id"
 API_KEY="api-key-retrieved-from-frontend"
+ADDITIONAL_ALLOWED_HOSTS="host.docker.internal"


### PR DESCRIPTION
## Summary
- Set `SERVER_URL` in `backend/env.template` to `http://host.docker.internal:8000` for local adapter usage.
- Add `ADDITIONAL_ALLOWED_HOSTS=host.docker.internal` to avoid host validation issues in local Docker-based calls.

## Replacement rationale
- Supersedes #55.
- The original PR branch is based on an older workflow/branch state.
- This replacement PR is rebased on current `main` so CI checks can run on current infrastructure and merge risk is reduced.
- No new features

## Notes
- Original contribution preserved via cherry-pick from the source commit.