### PR TITLE
ci: switch workflow jobs to github-hosted runners

### DIFF
--- a/.github/workflows/cicd-actions.yml
+++ b/.github/workflows/cicd-actions.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - '**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   DOCKER_DRIVER: overlay2
   DOCKER_TLS_CERTDIR: ""
@@ -16,7 +20,7 @@ env:
 
 jobs:
   create_dotenv_file:
-    runs-on: [ self-hosted ]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -60,7 +64,7 @@ jobs:
           include-hidden-files: true
 
   testing:
-    runs-on: [ self-hosted ]
+    runs-on: ubuntu-latest
     needs: create_dotenv_file
     steps:
       - name: Checkout code
@@ -114,7 +118,7 @@ jobs:
           path: backend/htmlcov
 
   cleanup:
-    runs-on: [ self-hosted ]
+    runs-on: ubuntu-latest
     needs: testing
     if: always()
     steps:
@@ -133,7 +137,7 @@ jobs:
           docker compose -f docker-compose.ci.yml down
 
   build_frontend_files:
-    runs-on: [ self-hosted ]
+    runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     needs: cleanup
     steps:
@@ -153,7 +157,7 @@ jobs:
           path: backend/assets/*
 
   build_and_push_container:
-    runs-on: [ self-hosted ]
+    runs-on: ubuntu-latest
     permissions:
       packages: write
       contents: read
@@ -198,7 +202,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   build_and_push_adapter:
-    runs-on: [ self-hosted ]
+    runs-on: ubuntu-latest
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
## Summary
- Switch workflow jobs from `self-hosted` to `ubuntu-latest` so CI can run while no self-hosted runners are available.
- Add workflow concurrency cancellation to stop superseded runs and reduce compute waste.
- Keep existing job gating (`if: github.ref == 'refs/heads/main'`) unchanged for publish jobs.

## Why now
- Current PR checks are blocked in `pending` state because no self-hosted runners are online.
- This change restores CI signal for pull requests without using large paid runners.